### PR TITLE
guminterceptor: add alt stack support

### DIFF
--- a/gum/guminterceptor.h
+++ b/gum/guminterceptor.h
@@ -92,6 +92,20 @@ GUM_API void gum_interceptor_with_lock_held (GumInterceptor * self,
     GumInterceptorLockedFunc func, gpointer user_data);
 GUM_API gboolean gum_interceptor_is_locked (GumInterceptor * self);
 
+// Configure the alternate stack for the interceptor. The alternate stack is
+// used by the interceptor to run the intercepted code on a separate stack to
+// avoid overflowing the current execution stack. The configuration applied when
+// constructing new threads contexts, so it generally must be called before
+// attaching the interceptor in order to apply.
+GUM_API void gum_interceptor_configure_alternate_stack (gint stack_size);
+
+// Configure the alternate stack for the interceptor. The alternate stack is
+// used by the interceptor to run the intercepted code on a separate stack to
+// avoid overflowing the current execution stack. The configuration applied when
+// constructing new threads contexts, so it generally must be called before
+// attaching the interceptor in order to apply.
+GUM_API void gum_interceptor_configure_alternate_stack (gint stack_size);
+
 GUM_API gsize gum_interceptor_detect_hook_size (gconstpointer code,
     csh capstone, cs_insn * insn);
 


### PR DESCRIPTION
This commit adds a new public API to gum to configure the size of an alternate stack to use for hooking. If the configuration is set, then when an interceptor is triggered, it will switch to this stack after the trampoline but before executing the handler. This is needed to support go or programs which do not have large and mutable thread stacks.

One note is that only x86_64 support has initially been added, and that it only applies for entry invocation listeners. Exit invocation listeners are not supported because they still would not work with go out-of-the-box because go doesn't like junk being added to call stacks.